### PR TITLE
Fixed bug in CPack.txt in RedHat related REGEX command.

### DIFF
--- a/CPack.txt
+++ b/CPack.txt
@@ -70,7 +70,7 @@ if(UNIX)
       endif(LINUX_ISSUE MATCHES "Fedora")
       # Red Hat case
       if(LINUX_ISSUE MATCHES "Red")
-        string(REGEX MATCH "Red Hat" "${LINUX_ISSUE}")
+        string(REGEX MATCH "Red Hat" REDHAT "${LINUX_ISSUE}")
         set(LINUX_NAME "RHEL_${CMAKE_MATCH_1}")  
         set(CPACK_GENERATOR "RPM")      
       endif(LINUX_ISSUE MATCHES "Red")


### PR DESCRIPTION
This small typo prevented building on RedHat systems.

Best regards,
Johannes