### PR TITLE
Workaround for bug where partioned files are not created as expected.

### DIFF
--- a/src/PvalueFilterAndSort.cpp
+++ b/src/PvalueFilterAndSort.cpp
@@ -36,6 +36,14 @@ void PvalueFilterAndSort::filterAndSort(const std::vector<std::string>& pvalFNs,
       std::cerr << "Sorting and filtering bin " << bin+1 << "/" << numFiles << " (" << (bin+1)*100/numFiles << "%)" << std::endl;
     }
     std::string partFileFN = resultFN + "." + boost::lexical_cast<std::string>(bin);
+    
+    // ignore files that do not exist
+    if (!boost::filesystem::exists(partFileFN)) { 
+        std::cerr << "Ignoring missing result file \"" << 
+                partFileFN << "\" does not exist." << std::endl;
+        continue;
+    }
+    
     filterAndSortSingleFile(partFileFN, removeUnidirected);
   }
   
@@ -135,6 +143,14 @@ void PvalueFilterAndSort::externalMergeSort(const std::string& resultFN, int num
     
     for (int bin = 0; bin < numFiles; ++bin) {
       std::string partFileFN = resultFN + "." + boost::lexical_cast<std::string>(bin);
+      
+      // ignore files that do not exist
+      if (!boost::filesystem::exists(partFileFN)) { 
+        std::cerr << "Ignoring missing result file \"" << 
+            partFileFN << "\" does not exist." << std::endl;
+        continue;
+      }
+      
       boost::iostreams::mapped_file mmap(partFileFN, 
             boost::iostreams::mapped_file::readonly);
       
@@ -196,6 +212,7 @@ void PvalueFilterAndSort::externalMergeSort(const std::string& resultFN, int num
 void PvalueFilterAndSort::writeBufferToPartFiles(std::vector<PvalueTriplet>& buffer, int numFiles, const std::string& resultFN) {
   std::vector< std::vector<PvalueTriplet> > hashBins(numFiles);
   BOOST_FOREACH (PvalueTriplet t, buffer) {
+    // TODO: this function might not work correctly
     int hashBin = ((t.scannr1.scannr % numFiles) + (t.scannr2.scannr % numFiles)) % numFiles;
     hashBins[hashBin].push_back(t);
   }
@@ -324,7 +341,7 @@ bool PvalueFilterAndSort::unitTest() {
   std::string pvalFN = "/media/storage/mergespec/data/batchtest/1300.ms2.pvalues_subset.tsv";
   //std::string pvalFN = "/media/storage/mergespec/data/batchcluster/Linfeng/Linfeng.pval_matrix_triplets.tsv";
   std::string resultFN = pvalFN + ".sorted.tsv";
-  
+ 
   bool removeUnidirected = true;
   bool tsvInput = true;
   std::vector<std::string> pvalFNs;

--- a/src/PvalueFilterAndSort.cpp
+++ b/src/PvalueFilterAndSort.cpp
@@ -41,7 +41,7 @@ void PvalueFilterAndSort::filterAndSort(const std::vector<std::string>& pvalFNs,
     if (!boost::filesystem::exists(partFileFN)) { 
         std::cerr << "Ignoring missing result file \"" << 
                 partFileFN << "\" does not exist." << std::endl;
-        continue;
+        //continue;
     }
     
     filterAndSortSingleFile(partFileFN, removeUnidirected);
@@ -148,7 +148,7 @@ void PvalueFilterAndSort::externalMergeSort(const std::string& resultFN, int num
       if (!boost::filesystem::exists(partFileFN)) { 
         std::cerr << "Ignoring missing result file \"" << 
             partFileFN << "\" does not exist." << std::endl;
-        continue;
+        //continue;
       }
       
       boost::iostreams::mapped_file mmap(partFileFN, 

--- a/src/PvalueFilterAndSort.h
+++ b/src/PvalueFilterAndSort.h
@@ -32,6 +32,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
 
+#include <boost/filesystem.hpp>
+
 #include "PvalueTriplet.h"
 #include "BinaryInterface.h"
 

--- a/src/SpectrumHandler.cpp
+++ b/src/SpectrumHandler.cpp
@@ -23,8 +23,11 @@ unsigned int SpectrumHandler::getScannr(pwiz::msdata::SpectrumPtr s) {
     ss >> tmp;
     if (tmp.substr(0,4) == "scan")
       return atoi(tmp.substr(5).c_str());
+
+    if (tmp.substr(0,6) == "index=")
+      return atoi(tmp.substr(7).c_str());
   }
-  std::cerr << "Warning: could not extract scannr. Returning scannr 0" << std::endl;
+  std::cerr << "Warning: could not extract scannr. Returning scannr 0 (" << s->id << ")" << std::endl;
   return 0;
 }
 


### PR DESCRIPTION
When sorting p-values multiple "part files" are created. For some
reason, these files are not created under certain conditions. All
functions that expect these files subsequently break.

This workaround simply ignores any missing files.