### PR TITLE
Replacing the use of spectrum id by the spectrum index

### DIFF
--- a/src/BatchPvalueVectors.cpp
+++ b/src/BatchPvalueVectors.cpp
@@ -154,7 +154,7 @@ void BatchPvalueVectors::writePvalueVectors(
   if (BatchGlobals::VERB > 1) {
     std::cerr << "Writing pvalue vectors" << std::endl;
   }
-  
+
   std::vector<BatchPvalueVector> headList, tailList, allList;
   double headOverlapLimit = pvalVecCollection_.front().precMass *
                              (1 + massRangePPM_*1e-6);
@@ -165,6 +165,7 @@ void BatchPvalueVectors::writePvalueVectors(
     if (i % 100000 == 0 && BatchGlobals::VERB > 2) {
       std::cerr << "Writing pvalue vector " << i << "/" << n << std::endl;
     }
+
     insert(pvalVecCollection_[i], allList);
     if (pvalVecCollection_[i].precMass < headOverlapLimit) {
       insert(pvalVecCollection_[i], headList);
@@ -173,7 +174,7 @@ void BatchPvalueVectors::writePvalueVectors(
       insert(pvalVecCollection_[i], tailList);
     }
   }
-  
+
   bool append = false;
   BinaryInterface::write<BatchPvalueVector>(allList, pvalueVectorsFN, append);
   BinaryInterface::write<BatchPvalueVector>(headList, pvalueVectorsHeadFN, append);
@@ -212,6 +213,12 @@ void BatchPvalueVectors::readPvalueVectorsFile(const std::string& pvalueVectorsF
   if (BatchGlobals::VERB > 1) {
     std::cerr << "Reading in pvalue vectors from " << pvalueVectorsFN << std::endl;
   }
+
+  if (!BatchGlobals::fileExists(pvalueVectorsFN)) {
+    std::cerr << "Ignoring missing file " << pvalueVectorsFN << std::endl;
+    return;
+  }
+
   boost::iostreams::mapped_file mmap(pvalueVectorsFN,
             boost::iostreams::mapped_file::readonly);
   

--- a/src/BatchSpectra.cpp
+++ b/src/BatchSpectra.cpp
@@ -30,6 +30,11 @@ void BatchSpectra::convertToBatchSpectra(std::string& spectrumFN,
   if (BatchGlobals::VERB > 1) {
     std::cerr << "Reading in spectra from " << spectrumFN << std::endl;
   }
+
+  if ( !boost::filesystem::exists( spectrumFN ) ) {
+    std::cerr << "Ignoring missing file " << spectrumFN << std::endl;
+    return;
+  }
   
   pwiz::msdata::SpectrumListPtr specList;
 
@@ -92,6 +97,11 @@ void BatchSpectra::readBatchSpectra(std::string& batchSpectraFN) {
   if (BatchGlobals::VERB > 1) {
     std::cerr << "Reading in spectra from " << batchSpectraFN << std::endl;
   }
+
+  if ( !boost::filesystem::exists( batchSpectraFN ) ) {
+    std::cerr << "Ignoring missing file " << batchSpectraFN << std::endl;
+    return;
+  } 
   
   BinaryInterface::read<BatchSpectrum>(batchSpectraFN, spectra_);
   

--- a/src/BatchSpectra.h
+++ b/src/BatchSpectra.h
@@ -21,6 +21,8 @@
 #include <vector>
 #include <string>
 
+#include <boost/filesystem.hpp>
+
 #include "pwiz/data/msdata/MSDataFile.hpp"
 
 #include "BatchGlobals.h"

--- a/src/PvalueFilterAndSort.cpp
+++ b/src/PvalueFilterAndSort.cpp
@@ -37,13 +37,6 @@ void PvalueFilterAndSort::filterAndSort(const std::vector<std::string>& pvalFNs,
     }
     std::string partFileFN = resultFN + "." + boost::lexical_cast<std::string>(bin);
     
-    // ignore files that do not exist
-    if (!boost::filesystem::exists(partFileFN)) { 
-        std::cerr << "Ignoring missing result file \"" << 
-                partFileFN << "\" does not exist." << std::endl;
-        //continue;
-    }
-    
     filterAndSortSingleFile(partFileFN, removeUnidirected);
   }
   
@@ -143,13 +136,6 @@ void PvalueFilterAndSort::externalMergeSort(const std::string& resultFN, int num
     
     for (int bin = 0; bin < numFiles; ++bin) {
       std::string partFileFN = resultFN + "." + boost::lexical_cast<std::string>(bin);
-      
-      // ignore files that do not exist
-      if (!boost::filesystem::exists(partFileFN)) { 
-        std::cerr << "Ignoring missing result file \"" << 
-            partFileFN << "\" does not exist." << std::endl;
-        //continue;
-      }
       
       boost::iostreams::mapped_file mmap(partFileFN, 
             boost::iostreams::mapped_file::readonly);

--- a/src/SpectrumHandler.cpp
+++ b/src/SpectrumHandler.cpp
@@ -17,7 +17,7 @@
 #include "SpectrumHandler.h"
 
 unsigned int SpectrumHandler::getScannr(pwiz::msdata::SpectrumPtr s) {
-  /*
+  
   std::stringstream ss(s->id);
   while (ss.good()) {
     std::string tmp;
@@ -29,7 +29,7 @@ unsigned int SpectrumHandler::getScannr(pwiz::msdata::SpectrumPtr s) {
       return atoi(tmp.substr(6).c_str());    
   }
   std::cerr << "Warning: could not extract scannr. Returning index " << s->index << " (" << s->id << ")" << std::endl;
-  */
+  
   // using the spectrum index should be more robust and
   // independet of the input format's indexing system
   return s->index;

--- a/src/SpectrumHandler.cpp
+++ b/src/SpectrumHandler.cpp
@@ -25,10 +25,10 @@ unsigned int SpectrumHandler::getScannr(pwiz::msdata::SpectrumPtr s) {
       return atoi(tmp.substr(5).c_str());
 
     if (tmp.substr(0,6) == "index=")
-      return atoi(tmp.substr(7).c_str());
+      return atoi(tmp.substr(6).c_str());    
   }
-  std::cerr << "Warning: could not extract scannr. Returning scannr 0 (" << s->id << ")" << std::endl;
-  return 0;
+  std::cerr << "Warning: could not extract scannr. Returning index " << s->index << " (" << s->id << ")" << std::endl;
+  return s->index;
 }
 
 double SpectrumHandler::interpolateIntensity(MZIntensityPair p1, MZIntensityPair p2, double mz) {

--- a/src/SpectrumHandler.cpp
+++ b/src/SpectrumHandler.cpp
@@ -17,6 +17,7 @@
 #include "SpectrumHandler.h"
 
 unsigned int SpectrumHandler::getScannr(pwiz::msdata::SpectrumPtr s) {
+  /*
   std::stringstream ss(s->id);
   while (ss.good()) {
     std::string tmp;
@@ -28,6 +29,9 @@ unsigned int SpectrumHandler::getScannr(pwiz::msdata::SpectrumPtr s) {
       return atoi(tmp.substr(6).c_str());    
   }
   std::cerr << "Warning: could not extract scannr. Returning index " << s->index << " (" << s->id << ")" << std::endl;
+  */
+  // using the spectrum index should be more robust and
+  // independet of the input format's indexing system
   return s->index;
 }
 

--- a/src/maracluster.cpp
+++ b/src/maracluster.cpp
@@ -397,6 +397,12 @@ int main(int argc, char* argv[]) {
             peakCounts.readFromFile(peakCountFN_);
             
             for (size_t i = 0; i < datFNs.size(); ++i) {
+              // make sure the file exists
+              if (!BatchGlobals::fileExists(datFNs[i])) {
+                std::cerr << "Ignoring missing data file " << datFNs[i] << std::endl;
+                continue;
+              }
+
               std::string datFN = datFNs[i];
               std::string pvalueVectorsBaseFN = datFN + ".pvalue_vectors";
               if (i < datFNs.size() - 1) {


### PR DESCRIPTION
The spectrum id format depends on the underlying filesystem. Therefore, the code will always break if some unexpected conversion is done. The spectrum index is always the 0-based index of the spectrum in the file and thus filetype independent.

Would this approach work for you?