### PR TITLE
Fix/gh actions fedora

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -27,20 +27,20 @@ jobs:
 
   build-fedora:
     runs-on: ubuntu-latest
-    container: 'fedora:35'
+    container: 'fedora:41'
     steps:
     - uses: actions/checkout@v2
     - name: preinstall
-      run: dnf install -y wget rsync make
+      run: dnf install -y wget rsync make gcc-c++ glibc-devel
     - name: create_dirs
-      run: mkdir -p ../my_rel ../my_build
+      run: mkdir -p my_rel my_build
     - name: configure_and_make
-      run: ./admin/builders/fedora64_build.sh -s `pwd`/.. -r `pwd`/../my_rel -b `pwd`/../my_build -g
+      run: ./admin/builders/fedora64_build.sh -s `pwd`/.. -r `pwd`/my_rel -b `pwd`/my_build -g
     - name: Upload packages
       uses: actions/upload-artifact@v4
       with:
         name: fedora-packages
-        path: ../my_rel
+        path: my_rel
 
   build-centos:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: preinstall
-      run: dnf install -y wget rsync make gcc-c++ glibc-devel
+      run: dnf install -y wget rsync make gcc-c++ glibc-devel glibc-static libstdc++-static
     - name: create_dirs
       run: mkdir -p my_rel my_build
     - name: configure_and_make

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -27,11 +27,11 @@ jobs:
 
   build-fedora:
     runs-on: ubuntu-latest
-    container: 'fedora:41'
+    container: 'fedora:39'
     steps:
     - uses: actions/checkout@v2
     - name: preinstall
-      run: dnf install -y wget rsync make gcc-c++ glibc-devel glibc-static libstdc++-static
+      run: dnf install -y wget rsync make glibc-static libstdc++-static
     - name: create_dirs
       run: mkdir -p my_rel my_build
     - name: configure_and_make

--- a/admin/builders/fedora64_build.sh
+++ b/admin/builders/fedora64_build.sh
@@ -35,10 +35,6 @@ CMAKE_BINARY=cmake # this can be overridden if a newer version of cmake is neede
 mkdir -p ${build_dir}/tools
 cd ${build_dir}/tools
 
-ls /usr/lib64/libstdc++.*
-ls /usr/lib64/libm.*
-ls /usr/lib64/libc.*
-
 if [ ! -f ${build_dir}/tools/pwiz_successful.txt ]; then
   ${src_dir}/maracluster/admin/builders/install_proteowizard.sh ${build_dir}/tools
 fi

--- a/admin/builders/fedora64_build.sh
+++ b/admin/builders/fedora64_build.sh
@@ -35,6 +35,10 @@ CMAKE_BINARY=cmake # this can be overridden if a newer version of cmake is neede
 mkdir -p ${build_dir}/tools
 cd ${build_dir}/tools
 
+ls /usr/lib64/libstdc++.*
+ls /usr/lib64/libm.*
+ls /usr/lib64/libc.*
+
 if [ ! -f ${build_dir}/tools/pwiz_successful.txt ]; then
   ${src_dir}/maracluster/admin/builders/install_proteowizard.sh ${build_dir}/tools
 fi


### PR DESCRIPTION
- Use Fedora 39 because it uses gcc-13 which ProteoWizard is using currently
- Add static libraries 